### PR TITLE
Require Node.js 8, drop support for array input, and add TypeScript definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
-  - '6'
-  - '4'

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export type UnaryFunction<T, R> = (value: T) => R | PromiseLike<R>;
  *
  * @param args - Input parameters.
  */
-export type Pipeline<T extends any[], R> = (...args: T) => Promise<R>;
+export type Pipeline<T extends unknown[], R> = (...args: T) => Promise<R>;
 
 /**
  * Returns an async `function` which accepts the same parameters as the first `function` of `input`.
@@ -27,17 +27,17 @@ export type Pipeline<T extends any[], R> = (...args: T) => Promise<R>;
  *
  * @param input - Iterated over sequentially when returned `function` is called.
  */
-declare function pipe<T extends any[], R>(f1: (...args: T) => R | PromiseLike<R>): Pipeline<T, R>;
-declare function pipe<T extends any[], R1, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R>): Pipeline<T, R>;
-declare function pipe<T extends any[], R1, R2, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R>): Pipeline<T, R>;
-declare function pipe<T extends any[], R1, R2, R3, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R>): Pipeline<T, R>;
-declare function pipe<T extends any[], R1, R2, R3, R4, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R>): Pipeline<T, R>;
-declare function pipe<T extends any[], R1, R2, R3, R4, R5, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R>): Pipeline<T, R>;
-declare function pipe<T extends any[], R1, R2, R3, R4, R5, R6, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R>): Pipeline<T, R>;
-declare function pipe<T extends any[], R1, R2, R3, R4, R5, R6, R7, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R7>, f8: UnaryFunction<R7, R>): Pipeline<T, R>;
-declare function pipe<T extends any[], R1, R2, R3, R4, R5, R6, R7, R8, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R7>, f8: UnaryFunction<R7, R8>, f9: UnaryFunction<R8, R>): Pipeline<T, R>;
+declare function pipe<T extends unknown[], R>(f1: (...args: T) => R | PromiseLike<R>): Pipeline<T, R>;
+declare function pipe<T extends unknown[], R1, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R>): Pipeline<T, R>;
+declare function pipe<T extends unknown[], R1, R2, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R>): Pipeline<T, R>;
+declare function pipe<T extends unknown[], R1, R2, R3, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R>): Pipeline<T, R>;
+declare function pipe<T extends unknown[], R1, R2, R3, R4, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R>): Pipeline<T, R>;
+declare function pipe<T extends unknown[], R1, R2, R3, R4, R5, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R>): Pipeline<T, R>;
+declare function pipe<T extends unknown[], R1, R2, R3, R4, R5, R6, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R>): Pipeline<T, R>;
+declare function pipe<T extends unknown[], R1, R2, R3, R4, R5, R6, R7, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R7>, f8: UnaryFunction<R7, R>): Pipeline<T, R>;
+declare function pipe<T extends unknown[], R1, R2, R3, R4, R5, R6, R7, R8, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R7>, f8: UnaryFunction<R7, R8>, f9: UnaryFunction<R8, R>): Pipeline<T, R>;
 
 // Fallbacks if more than 9 functions are passed as input (not type-safe).
-declare function pipe(...functions:((...args: any[]) => any | PromiseLike<any>)[]): Pipeline<unknown[], unknown>;
+declare function pipe(...functions:((...args: unknown[]) => unknown | PromiseLike<unknown>)[]): Pipeline<unknown[], unknown>;
 
 export default pipe;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,83 @@
+/**
+ * *Note about the nameing of generics*
+ *
+ * - `T`: Use when there is only one generic input parameter.
+ * - `R`: End result of the function / pipe.
+ * - `T<number>`: Used when there are more than one input parameter.
+ * - `R<number>`: Result of the n-th function inside the pipe that is passed to the (n+1)-th function.
+ */
+
+/**
+ * Function which accepts one parameter. Expected to return a `Promise` or value.
+ *
+ * @param x First parameter.
+ */
+export type UnaryFunction<T, R> = (x: T) => R | PromiseLike<R>;
+
+/**
+ * Function wich accepts two parameters. Expected to return a `Promise` or value.
+ *
+ * @param x First parameter.
+ * @param y Second parameter.
+ */
+export type BinaryFunction<T1, T2, R> = (x: T1, y:T2) => R | PromiseLike<R>;
+
+/**
+ * Function wich accepts three parameters. Expected to return a `Promise` or value.
+ *
+ * @param x First parameter.
+ * @param y Second parameter.
+ * @param z Third parameter.
+ */
+export type TernaryFunction<T1, T2, T3, R> = (x: T1, y:T2, z:T3) => R | PromiseLike<R>;
+
+/**
+ * Generic async `function` which can infer its parmeters. Expected to return a `Promise`.
+ *
+ * @param args Input parameters.
+ */
+export type Pipeline<T extends any[], R> = (...args:T) => Promise<R>;
+
+/**
+ * Returns an async `function` which accepts the same parameters as the first `function` of `input`.
+ * When the returned `function` is executed the `input` is sequentially iterated until one of the
+ * inputs throws or the last input is fulfilled.
+ *
+ * @param input Iterated over sequentially when returned `function` is called.
+ */
+declare function pipe <T, R>(f1:UnaryFunction<T, R>): Pipeline<[T], R>;
+declare function pipe <T, R1, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R>): Pipeline<[T], R>;
+declare function pipe <T, R1, R2, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R>): Pipeline<[T], R>;
+declare function pipe <T, R1, R2, R3, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R>): Pipeline<[T], R>;
+declare function pipe <T, R1, R2, R3, R4, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R>): Pipeline<[T], R>;
+declare function pipe <T, R1, R2, R3, R4, R5, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R>): Pipeline<[T], R>;
+declare function pipe <T, R1, R2, R3, R4, R5, R6, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R>): Pipeline<[T], R>;
+declare function pipe <T, R1, R2, R3, R4, R5, R6, R7, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R>): Pipeline<[T], R>;
+declare function pipe <T, R1, R2, R3, R4, R5, R6, R7, R8, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R8>, f9:UnaryFunction<R8, R>): Pipeline<[T], R>;
+
+declare function pipe <T1, T2, R>(f1:BinaryFunction<T1, T2, R>): Pipeline<[T1, T2], R>;
+declare function pipe <T1, T2, R1, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R>): Pipeline<[T1, T2], R>;
+declare function pipe <T1, T2, R1, R2, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R>): Pipeline<[T1, T2], R>;
+declare function pipe <T1, T2, R1, R2, R3, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R>): Pipeline<[T1, T2], R>;
+declare function pipe <T1, T2, R1, R2, R3, R4, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R>): Pipeline<[T1, T2], R>;
+declare function pipe <T1, T2, R1, R2, R3, R4, R5, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R>): Pipeline<[T1, T2], R>;
+declare function pipe <T1, T2, R1, R2, R3, R4, R5, R6, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R>): Pipeline<[T1, T2], R>;
+declare function pipe <T1, T2, R1, R2, R3, R4, R5, R6, R7, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R>): Pipeline<[T1, T2], R>;
+declare function pipe <T1, T2, R1, R2, R3, R4, R5, R6, R7, R8, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R8>, f9:UnaryFunction<R8, R>): Pipeline<[T1, T2], R>;
+
+declare function pipe <T1, T2, T3, R>(f1:TernaryFunction<T1, T2, T3, R>): Pipeline<[T1, T2, T3], R>;
+declare function pipe <T1, T2, T3, R1, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R>): Pipeline<[T1, T2, T3], R>;
+declare function pipe <T1, T2, T3, R1, R2, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R>): Pipeline<[T1, T2, T3], R>;
+declare function pipe <T1, T2, T3, R1, R2, R3, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R>): Pipeline<[T1, T2, T3], R>;
+declare function pipe <T1, T2, T3, R1, R2, R3, R4, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R>): Pipeline<[T1, T2, T3], R>;
+declare function pipe <T1, T2, T3, R1, R2, R3, R4, R5, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R>): Pipeline<[T1, T2, T3], R>;
+declare function pipe <T1, T2, T3, R1, R2, R3, R4, R5, R6, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R>): Pipeline<[T1, T2, T3], R>;
+declare function pipe <T1, T2, T3, R1, R2, R3, R4, R5, R6, R7, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R>): Pipeline<[T1, T2, T3], R>;
+declare function pipe <T1, T2, T3, R1, R2, R3, R4, R5, R6, R7, R8, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R8>, f9:UnaryFunction<R8, R>): Pipeline<[T1, T2, T3], R>;
+
+// Fallbacks when more than 9 functions are passed as input (not type-safe).
+declare function pipe (...fns:UnaryFunction<any, any>[]): Pipeline<[unknown], unknown>;
+declare function pipe (...fns:BinaryFunction<any, any, any>[]): Pipeline<[unknown, unknown], unknown>;
+declare function pipe (...fns:TernaryFunction<any, any, any, any>[]): Pipeline<[unknown, unknown, unknown], unknown>;
+
+export default pipe;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,8 @@
 /**
- * *Note about the nameing of generics*
+ * *Note about the naming of generics*
  *
  * - `T`: Use when there is only one generic input parameter.
  * - `R`: End result of the function / pipe.
- * - `T<number>`: Used when there are more than one input parameter.
  * - `R<number>`: Result of the n-th function inside the pipe that is passed to the (n+1)-th function.
  */
 
@@ -13,23 +12,6 @@
  * @param x First parameter.
  */
 export type UnaryFunction<T, R> = (x: T) => R | PromiseLike<R>;
-
-/**
- * Function wich accepts two parameters. Expected to return a `Promise` or value.
- *
- * @param x First parameter.
- * @param y Second parameter.
- */
-export type BinaryFunction<T1, T2, R> = (x: T1, y:T2) => R | PromiseLike<R>;
-
-/**
- * Function wich accepts three parameters. Expected to return a `Promise` or value.
- *
- * @param x First parameter.
- * @param y Second parameter.
- * @param z Third parameter.
- */
-export type TernaryFunction<T1, T2, T3, R> = (x: T1, y:T2, z:T3) => R | PromiseLike<R>;
 
 /**
  * Generic async `function` which can infer its parmeters. Expected to return a `Promise`.
@@ -45,39 +27,17 @@ export type Pipeline<T extends any[], R> = (...args:T) => Promise<R>;
  *
  * @param input Iterated over sequentially when returned `function` is called.
  */
-declare function pipe <T, R>(f1:UnaryFunction<T, R>): Pipeline<[T], R>;
-declare function pipe <T, R1, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R>): Pipeline<[T], R>;
-declare function pipe <T, R1, R2, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R>): Pipeline<[T], R>;
-declare function pipe <T, R1, R2, R3, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R>): Pipeline<[T], R>;
-declare function pipe <T, R1, R2, R3, R4, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R>): Pipeline<[T], R>;
-declare function pipe <T, R1, R2, R3, R4, R5, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R>): Pipeline<[T], R>;
-declare function pipe <T, R1, R2, R3, R4, R5, R6, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R>): Pipeline<[T], R>;
-declare function pipe <T, R1, R2, R3, R4, R5, R6, R7, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R>): Pipeline<[T], R>;
-declare function pipe <T, R1, R2, R3, R4, R5, R6, R7, R8, R>(f1:UnaryFunction<T, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R8>, f9:UnaryFunction<R8, R>): Pipeline<[T], R>;
+declare function pipe <T extends any[], R>(f1:(...args:T) => R | PromiseLike<R>): Pipeline<T, R>;
+declare function pipe <T extends any[], R1, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R>): Pipeline<T, R>;
+declare function pipe <T extends any[], R1, R2, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R>): Pipeline<T, R>;
+declare function pipe <T extends any[], R1, R2, R3, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R>): Pipeline<T, R>;
+declare function pipe <T extends any[], R1, R2, R3, R4, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R>): Pipeline<T, R>;
+declare function pipe <T extends any[], R1, R2, R3, R4, R5, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R>): Pipeline<T, R>;
+declare function pipe <T extends any[], R1, R2, R3, R4, R5, R6, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R>): Pipeline<T, R>;
+declare function pipe <T extends any[], R1, R2, R3, R4, R5, R6, R7, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R>): Pipeline<T, R>;
+declare function pipe <T extends any[], R1, R2, R3, R4, R5, R6, R7, R8, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R8>, f9:UnaryFunction<R8, R>): Pipeline<T, R>;
 
-declare function pipe <T1, T2, R>(f1:BinaryFunction<T1, T2, R>): Pipeline<[T1, T2], R>;
-declare function pipe <T1, T2, R1, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R>): Pipeline<[T1, T2], R>;
-declare function pipe <T1, T2, R1, R2, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R>): Pipeline<[T1, T2], R>;
-declare function pipe <T1, T2, R1, R2, R3, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R>): Pipeline<[T1, T2], R>;
-declare function pipe <T1, T2, R1, R2, R3, R4, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R>): Pipeline<[T1, T2], R>;
-declare function pipe <T1, T2, R1, R2, R3, R4, R5, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R>): Pipeline<[T1, T2], R>;
-declare function pipe <T1, T2, R1, R2, R3, R4, R5, R6, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R>): Pipeline<[T1, T2], R>;
-declare function pipe <T1, T2, R1, R2, R3, R4, R5, R6, R7, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R>): Pipeline<[T1, T2], R>;
-declare function pipe <T1, T2, R1, R2, R3, R4, R5, R6, R7, R8, R>(f1:BinaryFunction<T1, T2, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R8>, f9:UnaryFunction<R8, R>): Pipeline<[T1, T2], R>;
-
-declare function pipe <T1, T2, T3, R>(f1:TernaryFunction<T1, T2, T3, R>): Pipeline<[T1, T2, T3], R>;
-declare function pipe <T1, T2, T3, R1, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R>): Pipeline<[T1, T2, T3], R>;
-declare function pipe <T1, T2, T3, R1, R2, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R>): Pipeline<[T1, T2, T3], R>;
-declare function pipe <T1, T2, T3, R1, R2, R3, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R>): Pipeline<[T1, T2, T3], R>;
-declare function pipe <T1, T2, T3, R1, R2, R3, R4, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R>): Pipeline<[T1, T2, T3], R>;
-declare function pipe <T1, T2, T3, R1, R2, R3, R4, R5, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R>): Pipeline<[T1, T2, T3], R>;
-declare function pipe <T1, T2, T3, R1, R2, R3, R4, R5, R6, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R>): Pipeline<[T1, T2, T3], R>;
-declare function pipe <T1, T2, T3, R1, R2, R3, R4, R5, R6, R7, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R>): Pipeline<[T1, T2, T3], R>;
-declare function pipe <T1, T2, T3, R1, R2, R3, R4, R5, R6, R7, R8, R>(f1:TernaryFunction<T1, T2, T3, R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R8>, f9:UnaryFunction<R8, R>): Pipeline<[T1, T2, T3], R>;
-
-// Fallbacks when more than 9 functions are passed as input (not type-safe).
-declare function pipe (...fns:UnaryFunction<any, any>[]): Pipeline<[unknown], unknown>;
-declare function pipe (...fns:BinaryFunction<any, any, any>[]): Pipeline<[unknown, unknown], unknown>;
-declare function pipe (...fns:TernaryFunction<any, any, any, any>[]): Pipeline<[unknown, unknown, unknown], unknown>;
+// Fallbacks if more than 9 functions are passed as input (not type-safe).
+declare function pipe (...fns:((...args:any[]) => any | PromiseLike<any>)[]): Pipeline<unknown[], unknown>;
 
 export default pipe;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,43 +1,43 @@
 /**
- * *Note about the naming of generics*
+ * Note about the naming of generics:
  *
  * - `T`: Use when there is only one generic input parameter.
  * - `R`: End result of the function / pipe.
- * - `R<number>`: Result of the n-th function inside the pipe that is passed to the (n+1)-th function.
+ * - `R<number>`: Result of the nth function inside the pipe that is passed to the (n+1)-th function.
  */
 
 /**
  * Function which accepts one parameter. Expected to return a `Promise` or value.
  *
- * @param x First parameter.
+ * @param value - First parameter.
  */
-export type UnaryFunction<T, R> = (x: T) => R | PromiseLike<R>;
+export type UnaryFunction<T, R> = (value: T) => R | PromiseLike<R>;
 
 /**
  * Generic async `function` which can infer its parmeters. Expected to return a `Promise`.
  *
- * @param args Input parameters.
+ * @param args - Input parameters.
  */
-export type Pipeline<T extends any[], R> = (...args:T) => Promise<R>;
+export type Pipeline<T extends any[], R> = (...args: T) => Promise<R>;
 
 /**
  * Returns an async `function` which accepts the same parameters as the first `function` of `input`.
  * When the returned `function` is executed the `input` is sequentially iterated until one of the
  * inputs throws or the last input is fulfilled.
  *
- * @param input Iterated over sequentially when returned `function` is called.
+ * @param input - Iterated over sequentially when returned `function` is called.
  */
-declare function pipe <T extends any[], R>(f1:(...args:T) => R | PromiseLike<R>): Pipeline<T, R>;
-declare function pipe <T extends any[], R1, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R>): Pipeline<T, R>;
-declare function pipe <T extends any[], R1, R2, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R>): Pipeline<T, R>;
-declare function pipe <T extends any[], R1, R2, R3, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R>): Pipeline<T, R>;
-declare function pipe <T extends any[], R1, R2, R3, R4, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R>): Pipeline<T, R>;
-declare function pipe <T extends any[], R1, R2, R3, R4, R5, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R>): Pipeline<T, R>;
-declare function pipe <T extends any[], R1, R2, R3, R4, R5, R6, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R>): Pipeline<T, R>;
-declare function pipe <T extends any[], R1, R2, R3, R4, R5, R6, R7, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R>): Pipeline<T, R>;
-declare function pipe <T extends any[], R1, R2, R3, R4, R5, R6, R7, R8, R>(f1:(...args:T) => R1 | PromiseLike<R1>, f2:UnaryFunction<R1, R2>, f3:UnaryFunction<R2, R3>, f4:UnaryFunction<R3, R4>, f5:UnaryFunction<R4, R5>, f6:UnaryFunction<R5, R6>, f7:UnaryFunction<R6, R7>, f8:UnaryFunction<R7, R8>, f9:UnaryFunction<R8, R>): Pipeline<T, R>;
+declare function pipe<T extends any[], R>(f1: (...args: T) => R | PromiseLike<R>): Pipeline<T, R>;
+declare function pipe<T extends any[], R1, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R>): Pipeline<T, R>;
+declare function pipe<T extends any[], R1, R2, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R>): Pipeline<T, R>;
+declare function pipe<T extends any[], R1, R2, R3, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R>): Pipeline<T, R>;
+declare function pipe<T extends any[], R1, R2, R3, R4, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R>): Pipeline<T, R>;
+declare function pipe<T extends any[], R1, R2, R3, R4, R5, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R>): Pipeline<T, R>;
+declare function pipe<T extends any[], R1, R2, R3, R4, R5, R6, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R>): Pipeline<T, R>;
+declare function pipe<T extends any[], R1, R2, R3, R4, R5, R6, R7, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R7>, f8: UnaryFunction<R7, R>): Pipeline<T, R>;
+declare function pipe<T extends any[], R1, R2, R3, R4, R5, R6, R7, R8, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R7>, f8: UnaryFunction<R7, R8>, f9: UnaryFunction<R8, R>): Pipeline<T, R>;
 
 // Fallbacks if more than 9 functions are passed as input (not type-safe).
-declare function pipe (...fns:((...args:any[]) => any | PromiseLike<any>)[]): Pipeline<unknown[], unknown>;
+declare function pipe(...functions:((...args: any[]) => any | PromiseLike<any>)[]): Pipeline<unknown[], unknown>;
 
 export default pipe;

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
-module.exports = (...inputs) => {
-	if (inputs.length === 0) {
+module.exports = (...input) => {
+	if (input.length === 0) {
 		return Promise.reject(new Error('Expected at least one argument'));
 	}
 
-	const iterator = inputs[Symbol.iterator]();
+	const iterator = input[Symbol.iterator]();
 
 	const loop = async current => {
 		const {done, value} = iterator.next();

--- a/index.js
+++ b/index.js
@@ -1,17 +1,22 @@
 'use strict';
 
-// TODO: Use rest/spread when targeting Node.js 6
-
-module.exports = function (input) {
-	const args = Array.isArray(input) ? input : arguments;
-
-	if (args.length === 0) {
+module.exports = (...inputs) => {
+	if (inputs.length === 0) {
 		return Promise.reject(new Error('Expected at least one argument'));
 	}
 
-	return [].slice.call(args, 1).reduce((a, b) => {
-		return function () {
-			return Promise.resolve(a.apply(null, arguments)).then(b);
-		};
-	}, args[0]);
+	const iterator = inputs[Symbol.iterator]();
+
+	const loop = async current => {
+		const {done, value} = iterator.next();
+
+		if (done) {
+			return current;
+		}
+
+		const next = await value(current);
+		return loop(next);
+	};
+
+	return loop;
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = (...input) => {
 	if (input.length === 0) {
-		return Promise.reject(new Error('Expected at least one argument'));
+		throw new Error('Expected at least one argument');
 	}
 
 	const iterator = input[Symbol.iterator]();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,17 +1,17 @@
 import {expectType} from 'tsd-check';
 import pipe from '.';
 
-const unary = async (str:string) => `${str} Unicorn`;
-const binary = async (str:string, num:number) => unary(str.repeat(num));
-const ternary = async (str:string, num:number, bool:boolean) => bool ? binary(str, num) : unary(str);
+const unary = async (string: string) => `${string} Unicorn`;
+const binary = async (string: string, number: number) => unary(string.repeat(number));
+const ternary = async (string: string, number: number, boolean: boolean) => boolean ? binary(string, number) : unary(string);
 
-const identity = <T>(val:T) => val;
-const toNum = (str:string) => parseInt(str);
-const toFixed = (num:number) => num.toFixed(2);
+const identity = <T>(value: T) => value;
+const toNumber = (string: string) => parseInt(string);
+const toFixed = (number: number) => number.toFixed(2);
 
 // Unray
 expectType<string>(await pipe(unary)('❤️'));
-expectType<string>(await pipe(toNum, toFixed)('❤️'));
+expectType<string>(await pipe(toNumber, toFixed)('❤️'));
 
 expectType<string>(await pipe(unary, identity, identity)('❤️'));
 expectType<string>(await pipe(unary, identity, identity, identity)('❤️'));
@@ -25,7 +25,7 @@ expectType<unknown>(await pipe(unary, identity, identity, identity, identity, id
 
 // Binary
 expectType<string>(await pipe(binary)('❤️', 3));
-expectType<number>(await pipe(binary, toNum)('❤️', 10));
+expectType<number>(await pipe(binary, toNumber)('❤️', 10));
 
 expectType<string>(await pipe(binary, identity, identity)('❤️', 3));
 expectType<string>(await pipe(binary, identity, identity, identity)('❤️', 3));
@@ -39,7 +39,7 @@ expectType<unknown>(await pipe(binary, identity, identity, identity, identity, i
 
 // Tertary
 expectType<string>(await pipe(ternary)('❤️', 3, true));
-expectType<number>(await pipe(ternary, toNum)('❤️', 10, false));
+expectType<number>(await pipe(ternary, toNumber)('❤️', 10, false));
 
 expectType<string>(await pipe(ternary, identity, identity)('❤️', 3, true));
 expectType<string>(await pipe(ternary, identity, identity, identity)('❤️', 3, true));
@@ -52,10 +52,10 @@ expectType<string>(await pipe(ternary, identity, identity, identity, identity, i
 expectType<unknown>(await pipe(ternary, identity, identity, identity, identity, identity, identity, identity, identity, identity)('❤️', 12, false));
 
 // "Complex" examples
-const sq = (num:number) => num ** 2;
-const asResult = async <T>(result:T) => ({ result });
-const either = async (num:number) => num > 2 ? num : '🤪';
-const count = (num:number) => [...Array(num).keys()];
+const sq = (number: number) => number ** 2;
+const asResult = async <T>(result: T) => ({result});
+const either = async (number: number) => number > 2 ? number : '🤪';
+const count = (number: number) => [...Array(number).keys()];
 
 expectType<{ result: string }>(await pipe(sq, toFixed, asResult)(2));
 expectType<{ result: number | string }>(await pipe(sq, either, asResult)(2));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -57,6 +57,6 @@ const asResult = async <T>(result: T) => ({result});
 const either = async (number: number) => number > 2 ? number : '🤪';
 const count = (number: number) => [...Array(number).keys()];
 
-expectType<{ result: string }>(await pipe(sq, toFixed, asResult)(2));
-expectType<{ result: number | string }>(await pipe(sq, either, asResult)(2));
+expectType<{result: string}>(await pipe(sq, toFixed, asResult)(2));
+expectType<{result: number | string}>(await pipe(sq, either, asResult)(2));
 expectType<number[]>(await pipe(sq, count)(2));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -52,11 +52,11 @@ expectType<string>(await pipe(ternary, identity, identity, identity, identity, i
 expectType<unknown>(await pipe(ternary, identity, identity, identity, identity, identity, identity, identity, identity, identity)('❤️', 12, false));
 
 // "Complex" examples
-const sq = (number: number) => number ** 2;
+const byPowerOfTwo = (number: number) => number ** 2;
 const asResult = async <T>(result: T) => ({result});
 const either = async (number: number) => number > 2 ? number : '🤪';
 const count = (number: number) => [...Array(number).keys()];
 
-expectType<{result: string}>(await pipe(sq, toFixed, asResult)(2));
-expectType<{result: number | string}>(await pipe(sq, either, asResult)(2));
-expectType<number[]>(await pipe(sq, count)(2));
+expectType<{result: string}>(await pipe(byPowerOfTwo, toFixed, asResult)(2));
+expectType<{result: number | string}>(await pipe(byPowerOfTwo, either, asResult)(2));
+expectType<number[]>(await pipe(byPowerOfTwo, count)(2));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,62 @@
+import {expectType} from 'tsd-check';
+import pipe from '.';
+
+const unary = async (str:string) => `${str} Unicorn`;
+const binary = async (str:string, num:number) => unary(str.repeat(num));
+const ternary = async (str:string, num:number, bool:boolean) => bool ? binary(str, num) : unary(str);
+
+const identity = <T>(val:T) => val;
+const toNum = (str:string) => parseInt(str);
+const toFixed = (num:number) => num.toFixed(2);
+
+// Unray
+expectType<string>(await pipe(unary)('❤️'));
+expectType<string>(await pipe(toNum, toFixed)('❤️'));
+
+expectType<string>(await pipe(unary, identity, identity)('❤️'));
+expectType<string>(await pipe(unary, identity, identity, identity)('❤️'));
+expectType<string>(await pipe(unary, identity, identity, identity, identity)('❤️'));
+expectType<string>(await pipe(unary, identity, identity, identity, identity, identity)('❤️'));
+expectType<string>(await pipe(unary, identity, identity, identity, identity, identity, identity)('❤️'));
+expectType<string>(await pipe(unary, identity, identity, identity, identity, identity, identity, identity)('❤️'));
+expectType<string>(await pipe(unary, identity, identity, identity, identity, identity, identity, identity, identity)('❤️'));
+
+expectType<unknown>(await pipe(unary, identity, identity, identity, identity, identity, identity, identity, identity, identity)('❤️'));
+
+// Binary
+expectType<string>(await pipe(binary)('❤️', 3));
+expectType<number>(await pipe(binary, toNum)('❤️', 10));
+
+expectType<string>(await pipe(binary, identity, identity)('❤️', 3));
+expectType<string>(await pipe(binary, identity, identity, identity)('❤️', 3));
+expectType<string>(await pipe(binary, identity, identity, identity, identity)('❤️', 3));
+expectType<string>(await pipe(binary, identity, identity, identity, identity, identity)('❤️', 3));
+expectType<string>(await pipe(binary, identity, identity, identity, identity, identity, identity)('❤️', 3));
+expectType<string>(await pipe(binary, identity, identity, identity, identity, identity, identity, identity)('❤️', 3));
+expectType<string>(await pipe(binary, identity, identity, identity, identity, identity, identity, identity, identity)('❤️', 3));
+
+expectType<unknown>(await pipe(binary, identity, identity, identity, identity, identity, identity, identity, identity, identity)('❤️', 12));
+
+// Tertary
+expectType<string>(await pipe(ternary)('❤️', 3, true));
+expectType<number>(await pipe(ternary, toNum)('❤️', 10, false));
+
+expectType<string>(await pipe(ternary, identity, identity)('❤️', 3, true));
+expectType<string>(await pipe(ternary, identity, identity, identity)('❤️', 3, true));
+expectType<string>(await pipe(ternary, identity, identity, identity, identity)('❤️', 3, true));
+expectType<string>(await pipe(ternary, identity, identity, identity, identity, identity)('❤️', 3, true));
+expectType<string>(await pipe(ternary, identity, identity, identity, identity, identity, identity)('❤️', 3, true));
+expectType<string>(await pipe(ternary, identity, identity, identity, identity, identity, identity, identity)('❤️', 3, true));
+expectType<string>(await pipe(ternary, identity, identity, identity, identity, identity, identity, identity, identity)('❤️', 3, true));
+
+expectType<unknown>(await pipe(ternary, identity, identity, identity, identity, identity, identity, identity, identity, identity)('❤️', 12, false));
+
+// "Complex" examples
+const sq = (num:number) => num ** 2;
+const asResult = async <T>(result:T) => ({ result });
+const either = async (num:number) => num > 2 ? num : '🤪';
+const count = (num:number) => [...Array(num).keys()];
+
+expectType<{ result: string }>(await pipe(sq, toFixed, asResult)(2));
+expectType<{ result: number | string }>(await pipe(sq, either, asResult)(2));
+expectType<number[]>(await pipe(sq, count)(2));

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "node": ">=8"
   },
   "scripts": {
-    "test": "xo && ava"
+    "test": "xo && ava && tsd-check"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "keywords": [
     "promise",
@@ -36,7 +37,8 @@
   ],
   "devDependencies": {
     "ava": "*",
-    "sinon": "*",
+    "sinon": "^7.2.3",
+    "tsd-check": "^0.3.0",
     "xo": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "scripts": {
     "test": "xo && ava"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "devDependencies": {
     "ava": "*",
+    "sinon": "*",
     "xo": "*"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,6 @@ pipeline('❤️').then(console.log);
 
 The `input` functions are applied from left to right.
 
-You can also specify an array as the first argument instead of multiple function arguments. Mostly only useful if you have to support Node.js 4. With Node.js 6 and above you can just use spread syntax.
-
 #### input
 
 Type: `Function`

--- a/test.js
+++ b/test.js
@@ -52,3 +52,8 @@ test('immediately stops on error', async t => {
 	t.true(two.called);
 	t.false(three.called);
 });
+
+test('requires at least one input', t => {
+	const error = t.throws(() => m(), Error);
+	t.is(error.message, 'Expected at least one argument');
+});

--- a/test.js
+++ b/test.js
@@ -1,11 +1,12 @@
 import test from 'ava';
+import sinon from 'sinon';
 import m from '.';
 
-const addUnicorn = str => Promise.resolve(`${str} Unicorn`);
+const addUnicorn = async str => `${str} Unicorn`;
 const addRainbow = str => Promise.resolve(`${str} Rainbow`);
 const addNonPromise = str => `${str} Foo`;
 
-test(async t => {
+test('p-pipe', async t => {
 	const single = m(addUnicorn);
 	t.is(await single('❤️'), '❤️ Unicorn');
 
@@ -15,6 +16,39 @@ test(async t => {
 	const mixed = m(addNonPromise, addUnicorn, addRainbow);
 	t.is(await mixed('❤️'), '❤️ Foo Unicorn Rainbow');
 
-	const array = m([addUnicorn, addRainbow]);
+	const array = m(...[addUnicorn, addRainbow]);
 	t.is(await array('❤️'), '❤️ Unicorn Rainbow');
+});
+
+test('is lazy', async t => {
+	const spy = sinon.spy();
+	const fn = m(spy);
+
+	t.false(spy.called);
+
+	await fn('❤️');
+
+	t.true(spy.called);
+});
+
+test('throws', async t => {
+	const whoops = async () => {
+		throw new Error('💔');
+	};
+
+	const fn = async () => m(whoops)('🧐');
+	await t.throwsAsync(fn, Error, '💔');
+});
+
+test('immediately stops on error', async t => {
+	const one = sinon.spy();
+	const two = sinon.stub().throws('😭');
+	const three = sinon.spy();
+
+	const fn = async () => m(one, two, three)('🧐');
+	await t.throwsAsync(fn);
+
+	t.true(one.called);
+	t.true(two.called);
+	t.false(three.called);
 });


### PR DESCRIPTION
- Refactor to use `async`/`await`
- Use recursion instead of `reduce`
- Add TypeScript typings
- Drops support of array input in favor if rest/spread.

BREAKING CHANGES:

- The following syntax is no longer supported

```js
const pipeline = pPipe([addUnicorn, addRainbow]);
```

insteas use:

```js
const pipeline = pPipe(...[addUnicorn, addRainbow]);
```

or 

```js
const pipeline = pPipe(addUnicorn, addRainbow);
```

- Only supports node v8 and up.