### PR TITLE
Always use a fresh iterator

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,24 @@
 'use strict';
 
-module.exports = (...input) => {
-	if (input.length === 0) {
+module.exports = (...iterable) => {
+	if (iterable.length === 0) {
 		throw new Error('Expected at least one argument');
 	}
 
-	const iterator = input[Symbol.iterator]();
+	return input => {
+		const iterator = iterable[Symbol.iterator]();
 
-	const loop = async current => {
-		const {done, value} = iterator.next();
+		const loop = async current => {
+			const {done, value} = iterator.next();
 
-		if (done) {
-			return current;
-		}
+			if (done) {
+				return current;
+			}
 
-		const next = await value(current);
-		return loop(next);
+			const next = await value(current);
+			return loop(next);
+		};
+
+		return loop(input);
 	};
-
-	return loop;
 };

--- a/test.js
+++ b/test.js
@@ -58,3 +58,10 @@ test('requires at least one input', t => {
 		pPipe();
 	}, 'Expected at least one argument');
 });
+
+test('reuse pipe', async t => {
+	const task = pPipe(addUnicorn);
+
+	t.is(await task('❤️'), '❤️ Unicorn');
+	t.is(await task('❤️'), '❤️ Unicorn');
+});


### PR DESCRIPTION
In 2.0 there was a regression introduced regarding the reusability of the pipe.

```js
const pipe = require('p-pipe');

const fn = () => 'whoops';
const task = pipe(fn);

const t1 = await task(); // returns 'whoops'
const t2 = await task(); // returns undefined
```

This was caused by not resetting the `iterator`. Every subsequent use of the `task` was reusing the same iterator, which already finished iterating in the first usage 🤦‍♂️

This patch will make sure a fresh iterator is created on every usage of the `task`.

Also added a test to make sure this is not happening again!

Fixes #6 