### PR TITLE
Fix TypeScript definition, refactor definition to CommonJS compatible export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,43 +1,152 @@
-/**
- * Note about the naming of generics:
- *
- * - `T`: Use when there is only one generic input parameter.
- * - `R`: End result of the function / pipe.
- * - `R<number>`: Result of the nth function inside the pipe that is passed to the (n+1)-th function.
- */
+declare namespace pPipe {
+	type UnaryFunction<ValueType, ReturnType> = (
+		value: ValueType
+	) => ReturnType | PromiseLike<ReturnType>;
+
+	type Pipeline<ValueType, ReturnType> = (
+		value: ValueType
+	) => Promise<ReturnType>;
+}
 
 /**
- * Function which accepts one parameter. Expected to return a `Promise` or value.
- *
- * @param value - First parameter.
- */
-export type UnaryFunction<T, R> = (value: T) => R | PromiseLike<R>;
+Compose promise-returning & async functions into a reusable pipeline.
 
-/**
- * Generic async `function` which can infer its parmeters. Expected to return a `Promise`.
- *
- * @param args - Input parameters.
- */
-export type Pipeline<T extends unknown[], R> = (...args: T) => Promise<R>;
+@param ...input - Iterated over sequentially when returned `function` is called.
+@returns The `input` functions are applied from left to right.
 
-/**
- * Returns an async `function` which accepts the same parameters as the first `function` of `input`.
- * When the returned `function` is executed the `input` is sequentially iterated until one of the
- * inputs throws or the last input is fulfilled.
- *
- * @param input - Iterated over sequentially when returned `function` is called.
- */
-declare function pipe<T extends unknown[], R>(f1: (...args: T) => R | PromiseLike<R>): Pipeline<T, R>;
-declare function pipe<T extends unknown[], R1, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R>): Pipeline<T, R>;
-declare function pipe<T extends unknown[], R1, R2, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R>): Pipeline<T, R>;
-declare function pipe<T extends unknown[], R1, R2, R3, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R>): Pipeline<T, R>;
-declare function pipe<T extends unknown[], R1, R2, R3, R4, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R>): Pipeline<T, R>;
-declare function pipe<T extends unknown[], R1, R2, R3, R4, R5, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R>): Pipeline<T, R>;
-declare function pipe<T extends unknown[], R1, R2, R3, R4, R5, R6, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R>): Pipeline<T, R>;
-declare function pipe<T extends unknown[], R1, R2, R3, R4, R5, R6, R7, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R7>, f8: UnaryFunction<R7, R>): Pipeline<T, R>;
-declare function pipe<T extends unknown[], R1, R2, R3, R4, R5, R6, R7, R8, R>(f1: (...args: T) => R1 | PromiseLike<R1>, f2: UnaryFunction<R1, R2>, f3: UnaryFunction<R2, R3>, f4: UnaryFunction<R3, R4>, f5: UnaryFunction<R4, R5>, f6: UnaryFunction<R5, R6>, f7: UnaryFunction<R6, R7>, f8: UnaryFunction<R7, R8>, f9: UnaryFunction<R8, R>): Pipeline<T, R>;
+@example
+```
+import pPipe = require('p-pipe');
+
+const addUnicorn = async string => `${string} Unicorn`;
+const addRainbow = async string => `${string} Rainbow`;
+
+const pipeline = pPipe(addUnicorn, addRainbow);
+
+(async () => {
+	console.log(await pipeline('❤️'));
+	//=> '❤️ Unicorn Rainbow'
+})();
+```
+*/
+declare function pPipe<ValueType, ReturnType>(
+	f1: pPipe.UnaryFunction<ValueType, ReturnType>
+): pPipe.Pipeline<ValueType, ReturnType>;
+declare function pPipe<ValueType, ResultValue1, ReturnType>(
+	f1: pPipe.UnaryFunction<ValueType, ResultValue1>,
+	f2: pPipe.UnaryFunction<ResultValue1, ReturnType>
+): pPipe.Pipeline<ValueType, ReturnType>;
+declare function pPipe<ValueType, ResultValue1, ResultValue2, ReturnType>(
+	f1: pPipe.UnaryFunction<ValueType, ResultValue1>,
+	f2: pPipe.UnaryFunction<ResultValue1, ResultValue2>,
+	f3: pPipe.UnaryFunction<ResultValue2, ReturnType>
+): pPipe.Pipeline<ValueType, ReturnType>;
+declare function pPipe<
+	ValueType,
+	ResultValue1,
+	ResultValue2,
+	ResultValue3,
+	ReturnType
+>(
+	f1: pPipe.UnaryFunction<ValueType, ResultValue1>,
+	f2: pPipe.UnaryFunction<ResultValue1, ResultValue2>,
+	f3: pPipe.UnaryFunction<ResultValue2, ResultValue3>,
+	f4: pPipe.UnaryFunction<ResultValue3, ReturnType>
+): pPipe.Pipeline<ValueType, ReturnType>;
+declare function pPipe<
+	ValueType,
+	ResultValue1,
+	ResultValue2,
+	ResultValue3,
+	ResultValue4,
+	ReturnType
+>(
+	f1: pPipe.UnaryFunction<ValueType, ResultValue1>,
+	f2: pPipe.UnaryFunction<ResultValue1, ResultValue2>,
+	f3: pPipe.UnaryFunction<ResultValue2, ResultValue3>,
+	f4: pPipe.UnaryFunction<ResultValue3, ResultValue4>,
+	f5: pPipe.UnaryFunction<ResultValue4, ReturnType>
+): pPipe.Pipeline<ValueType, ReturnType>;
+declare function pPipe<
+	ValueType,
+	ResultValue1,
+	ResultValue2,
+	ResultValue3,
+	ResultValue4,
+	ResultValue5,
+	ReturnType
+>(
+	f1: pPipe.UnaryFunction<ValueType, ResultValue1>,
+	f2: pPipe.UnaryFunction<ResultValue1, ResultValue2>,
+	f3: pPipe.UnaryFunction<ResultValue2, ResultValue3>,
+	f4: pPipe.UnaryFunction<ResultValue3, ResultValue4>,
+	f5: pPipe.UnaryFunction<ResultValue4, ResultValue5>,
+	f6: pPipe.UnaryFunction<ResultValue5, ReturnType>
+): pPipe.Pipeline<ValueType, ReturnType>;
+declare function pPipe<
+	ValueType,
+	ResultValue1,
+	ResultValue2,
+	ResultValue3,
+	ResultValue4,
+	ResultValue5,
+	ResultValue6,
+	ReturnType
+>(
+	f1: pPipe.UnaryFunction<ValueType, ResultValue1>,
+	f2: pPipe.UnaryFunction<ResultValue1, ResultValue2>,
+	f3: pPipe.UnaryFunction<ResultValue2, ResultValue3>,
+	f4: pPipe.UnaryFunction<ResultValue3, ResultValue4>,
+	f5: pPipe.UnaryFunction<ResultValue4, ResultValue5>,
+	f6: pPipe.UnaryFunction<ResultValue5, ResultValue6>,
+	f7: pPipe.UnaryFunction<ResultValue6, ReturnType>
+): pPipe.Pipeline<ValueType, ReturnType>;
+declare function pPipe<
+	ValueType,
+	ResultValue1,
+	ResultValue2,
+	ResultValue3,
+	ResultValue4,
+	ResultValue5,
+	ResultValue6,
+	ResultValue7,
+	ReturnType
+>(
+	f1: pPipe.UnaryFunction<ValueType, ResultValue1>,
+	f2: pPipe.UnaryFunction<ResultValue1, ResultValue2>,
+	f3: pPipe.UnaryFunction<ResultValue2, ResultValue3>,
+	f4: pPipe.UnaryFunction<ResultValue3, ResultValue4>,
+	f5: pPipe.UnaryFunction<ResultValue4, ResultValue5>,
+	f6: pPipe.UnaryFunction<ResultValue5, ResultValue6>,
+	f7: pPipe.UnaryFunction<ResultValue6, ResultValue7>,
+	f8: pPipe.UnaryFunction<ResultValue7, ReturnType>
+): pPipe.Pipeline<ValueType, ReturnType>;
+declare function pPipe<
+	ValueType,
+	ResultValue1,
+	ResultValue2,
+	ResultValue3,
+	ResultValue4,
+	ResultValue5,
+	ResultValue6,
+	ResultValue7,
+	ResultValue8,
+	ReturnType
+>(
+	f1: pPipe.UnaryFunction<ValueType, ResultValue1>,
+	f2: pPipe.UnaryFunction<ResultValue1, ResultValue2>,
+	f3: pPipe.UnaryFunction<ResultValue2, ResultValue3>,
+	f4: pPipe.UnaryFunction<ResultValue3, ResultValue4>,
+	f5: pPipe.UnaryFunction<ResultValue4, ResultValue5>,
+	f6: pPipe.UnaryFunction<ResultValue5, ResultValue6>,
+	f7: pPipe.UnaryFunction<ResultValue6, ResultValue7>,
+	f8: pPipe.UnaryFunction<ResultValue7, ResultValue8>,
+	f9: pPipe.UnaryFunction<ResultValue8, ReturnType>
+): pPipe.Pipeline<ValueType, ReturnType>;
 
 // Fallbacks if more than 9 functions are passed as input (not type-safe).
-declare function pipe(...functions:((...args: unknown[]) => unknown | PromiseLike<unknown>)[]): Pipeline<unknown[], unknown>;
+declare function pPipe(
+	...functions: (pPipe.UnaryFunction<any, unknown>)[]
+): pPipe.Pipeline<unknown, unknown>;
 
-export default pipe;
+export = pPipe;

--- a/index.js
+++ b/index.js
@@ -1,24 +1,17 @@
 'use strict';
 
-module.exports = (...iterable) => {
-	if (iterable.length === 0) {
+module.exports = (...functions) => {
+	if (functions.length === 0) {
 		throw new Error('Expected at least one argument');
 	}
 
-	return input => {
-		const iterator = iterable[Symbol.iterator]();
+	return async input => {
+		let currentValue = input;
 
-		const loop = async current => {
-			const {done, value} = iterator.next();
+		for (const fn of functions) {
+			currentValue = await fn(currentValue); // eslint-disable-line no-await-in-loop
+		}
 
-			if (done) {
-				return current;
-			}
-
-			const next = await value(current);
-			return loop(next);
-		};
-
-		return loop(input);
+		return currentValue;
 	};
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,62 +1,77 @@
-import {expectType} from 'tsd-check';
-import pipe from '.';
+import {expectType} from 'tsd';
+import pPipe = require('.');
 
-const unary = async (string: string) => `${string} Unicorn`;
-const binary = async (string: string, number: number) => unary(string.repeat(number));
-const ternary = async (string: string, number: number, boolean: boolean) => boolean ? binary(string, number) : unary(string);
+const fn = async (string: string) => `${string} Unicorn`;
 
 const identity = <T>(value: T) => value;
 const toNumber = (string: string) => parseInt(string);
 const toFixed = (number: number) => number.toFixed(2);
 
-// Unray
-expectType<string>(await pipe(unary)('❤️'));
-expectType<string>(await pipe(toNumber, toFixed)('❤️'));
+expectType<Promise<string>>(pPipe(fn)('❤️'));
+expectType<Promise<string>>(pPipe(toNumber, toFixed)('❤️'));
 
-expectType<string>(await pipe(unary, identity, identity)('❤️'));
-expectType<string>(await pipe(unary, identity, identity, identity)('❤️'));
-expectType<string>(await pipe(unary, identity, identity, identity, identity)('❤️'));
-expectType<string>(await pipe(unary, identity, identity, identity, identity, identity)('❤️'));
-expectType<string>(await pipe(unary, identity, identity, identity, identity, identity, identity)('❤️'));
-expectType<string>(await pipe(unary, identity, identity, identity, identity, identity, identity, identity)('❤️'));
-expectType<string>(await pipe(unary, identity, identity, identity, identity, identity, identity, identity, identity)('❤️'));
+expectType<Promise<string>>(pPipe(fn, identity, identity)('❤️'));
+expectType<Promise<string>>(pPipe(fn, identity, identity, identity)('❤️'));
+expectType<Promise<string>>(
+	pPipe(fn, identity, identity, identity, identity)('❤️')
+);
+expectType<Promise<string>>(
+	pPipe(fn, identity, identity, identity, identity, identity)('❤️')
+);
+expectType<Promise<string>>(
+	pPipe(fn, identity, identity, identity, identity, identity, identity)('❤️')
+);
+expectType<Promise<string>>(
+	pPipe(
+		fn,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity
+	)('❤️')
+);
+expectType<Promise<string>>(
+	pPipe(
+		fn,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity
+	)('❤️')
+);
 
-expectType<unknown>(await pipe(unary, identity, identity, identity, identity, identity, identity, identity, identity, identity)('❤️'));
-
-// Binary
-expectType<string>(await pipe(binary)('❤️', 3));
-expectType<number>(await pipe(binary, toNumber)('❤️', 10));
-
-expectType<string>(await pipe(binary, identity, identity)('❤️', 3));
-expectType<string>(await pipe(binary, identity, identity, identity)('❤️', 3));
-expectType<string>(await pipe(binary, identity, identity, identity, identity)('❤️', 3));
-expectType<string>(await pipe(binary, identity, identity, identity, identity, identity)('❤️', 3));
-expectType<string>(await pipe(binary, identity, identity, identity, identity, identity, identity)('❤️', 3));
-expectType<string>(await pipe(binary, identity, identity, identity, identity, identity, identity, identity)('❤️', 3));
-expectType<string>(await pipe(binary, identity, identity, identity, identity, identity, identity, identity, identity)('❤️', 3));
-
-expectType<unknown>(await pipe(binary, identity, identity, identity, identity, identity, identity, identity, identity, identity)('❤️', 12));
-
-// Tertary
-expectType<string>(await pipe(ternary)('❤️', 3, true));
-expectType<number>(await pipe(ternary, toNumber)('❤️', 10, false));
-
-expectType<string>(await pipe(ternary, identity, identity)('❤️', 3, true));
-expectType<string>(await pipe(ternary, identity, identity, identity)('❤️', 3, true));
-expectType<string>(await pipe(ternary, identity, identity, identity, identity)('❤️', 3, true));
-expectType<string>(await pipe(ternary, identity, identity, identity, identity, identity)('❤️', 3, true));
-expectType<string>(await pipe(ternary, identity, identity, identity, identity, identity, identity)('❤️', 3, true));
-expectType<string>(await pipe(ternary, identity, identity, identity, identity, identity, identity, identity)('❤️', 3, true));
-expectType<string>(await pipe(ternary, identity, identity, identity, identity, identity, identity, identity, identity)('❤️', 3, true));
-
-expectType<unknown>(await pipe(ternary, identity, identity, identity, identity, identity, identity, identity, identity, identity)('❤️', 12, false));
+expectType<unknown>(
+	pPipe(
+		fn,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity,
+		identity
+	)('❤️')
+);
 
 // "Complex" examples
 const byPowerOfTwo = (number: number) => number ** 2;
 const asResult = async <T>(result: T) => ({result});
-const either = async (number: number) => number > 2 ? number : '🤪';
+const either = async (number: number) => (number > 2 ? number : '🤪');
 const count = (number: number) => [...Array(number).keys()];
 
-expectType<{result: string}>(await pipe(byPowerOfTwo, toFixed, asResult)(2));
-expectType<{result: number | string}>(await pipe(byPowerOfTwo, either, asResult)(2));
-expectType<number[]>(await pipe(byPowerOfTwo, count)(2));
+expectType<Promise<{result: string}>>(
+	pPipe(byPowerOfTwo, toFixed, asResult)(2)
+);
+expectType<Promise<{result: number | string}>>(
+	pPipe(byPowerOfTwo, either, asResult)(2)
+);
+expectType<Promise<number[]>>(pPipe(byPowerOfTwo, count)(2));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd-check"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -36,9 +36,9 @@
 		"bluebird"
 	],
 	"devDependencies": {
-		"ava": "^1.2.0",
-		"sinon": "^7.2.3",
-		"tsd-check": "^0.3.0",
+		"ava": "^1.4.1",
+		"sinon": "^7.3.1",
+		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	}
 }


### PR DESCRIPTION
**BREAKING CHANGE**:

- default export was declared but not provided in JS
- types were incorrectly allowing multiple arguments to first fn in pipeline
- simplified implementation