### PR TITLE
Change the TypeScript types to allow no input

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare namespace pPipe {
 	) => ReturnType | PromiseLike<ReturnType>;
 
 	type Pipeline<ValueType, ReturnType> = (
-		value: ValueType
+		value?: ValueType
 	) => Promise<ReturnType>;
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,12 +2,14 @@ import {expectType} from 'tsd';
 import pPipe = require('.');
 
 const fn = async (string: string) => `${string} Unicorn`;
+const noInput = async () => 'called without input';
 
 const identity = <T>(value: T) => value;
 const toNumber = (string: string) => parseInt(string);
 const toFixed = (number: number) => number.toFixed(2);
 
 expectType<Promise<string>>(pPipe(fn)('❤️'));
+expectType<Promise<string>>(pPipe(noInput)());
 expectType<Promise<string>>(pPipe(toNumber, toFixed)('❤️'));
 
 expectType<Promise<string>>(pPipe(fn, identity, identity)('❤️'));
@@ -47,6 +49,14 @@ expectType<Promise<string>>(
 	)('❤️')
 );
 
+expectType<Promise<string>>(
+	pPipe(
+		noInput,
+		identity,
+		identity
+	)()
+);
+
 expectType<unknown>(
 	pPipe(
 		fn,
@@ -61,12 +71,20 @@ expectType<unknown>(
 		identity
 	)('❤️')
 );
+expectType<unknown>(
+	pPipe(
+		noInput,
+		identity,
+		identity
+	)()
+);
 
 // "Complex" examples
 const byPowerOfTwo = (number: number) => number ** 2;
 const asResult = async <T>(result: T) => ({result});
 const either = async (number: number) => (number > 2 ? number : '🤪');
 const count = (number: number) => [...Array(number).keys()];
+const fetchNumber = async () => 2;
 
 expectType<Promise<{result: string}>>(
 	pPipe(byPowerOfTwo, toFixed, asResult)(2)
@@ -75,3 +93,6 @@ expectType<Promise<{result: number | string}>>(
 	pPipe(byPowerOfTwo, either, asResult)(2)
 );
 expectType<Promise<number[]>>(pPipe(byPowerOfTwo, count)(2));
+expectType<Promise<{result: number | string}>>(
+	pPipe(fetchNumber, either, asResult)()
+);

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ import pPipe from '.';
 const addUnicorn = async string => `${string} Unicorn`;
 const addRainbow = string => Promise.resolve(`${string} Rainbow`);
 const addNonPromise = string => `${string} Foo`;
+const fetchString = () => 'without input';
 
 test('main', async t => {
 	const single = pPipe(addUnicorn);
@@ -64,4 +65,10 @@ test('reuse pipe', async t => {
 
 	t.is(await task('❤️'), '❤️ Unicorn');
 	t.is(await task('❤️'), '❤️ Unicorn');
+});
+
+test('calls function without input', async t => {
+	const withoutInput = pPipe(fetchString, addUnicorn);
+
+	t.is(await withoutInput(), 'without input Unicorn');
 });


### PR DESCRIPTION
Change type definition to call `pPipe` function without input.

```js
const fetchData = () => 'data'
const handleData = (data) => {
...
}

pPipe(fetchData, handleData)()
```

resolve: #8 